### PR TITLE
deprecate fedora 42

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -2,6 +2,7 @@
 
 # project information
 project_name: baseimage-fedora
+project_deprecation_status: true
 full_custom_readme: |
   {% raw -%}
   [![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)](https://linuxserver.io)


### PR DESCRIPTION
Rolling out 44 now this kills off builds on 42.
